### PR TITLE
Add cart file browser

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,20 +6,19 @@
  */
 
 #include <stdio.h>
+#include "p8_browse.h"
 #include "p8_parser.h"
 #include "p8_emu.h"
 
 int main(int argc, char *argv[])
 {
-    if (argc < 2)
-    {
-        printf("Usage: %s <p8_file>\n", argv[0]);
-        return 1;
-    }
-
-    char *file_name = argv[1];
-
-    p8_init_file(file_name);
+    const char *file_name;
+    if (argc >= 2)
+        file_name = argv[1];
+    else
+        file_name = browse_for_cart();
+    if (file_name != NULL)
+        p8_init_file(file_name);
     p8_shutdown();
 
     return 0;

--- a/src/p8_browse.c
+++ b/src/p8_browse.c
@@ -1,0 +1,231 @@
+/**
+ * Copyright (C) 2025 Chris January
+ */
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <malloc.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "p8_browse.h"
+#include "p8_emu.h"
+#include "p8_lua_helper.h"
+
+#ifdef NEXTP8
+#define DEFAULT_PATH "0:/nextp8/carts"
+#define FALLBACK_PATH "0:/"
+#else
+#define DEFAULT_PATH "carts"
+#define FALLBACK_PATH "."
+#endif
+
+struct dir_entry {
+    const char *file_name;
+    bool is_dir;
+};
+
+static const char *pwd = NULL;
+static struct dir_entry *dir_contents = NULL;
+static int nitems = 0;
+static int capacity = 0;
+static int current_item = 0;
+static void clear_dir_contents(void) {
+    for (int i=0;i<nitems;++i)
+        free((char *)dir_contents[i].file_name);
+    nitems = 0;
+    current_item = 0;
+}
+static void append_dir_entry(const char *file_name, bool is_dir)
+{
+    if (nitems == capacity) {
+        if (capacity == 0)
+            capacity = 10;
+        else
+            capacity *= 2;
+        dir_contents = realloc(dir_contents, sizeof(dir_contents[0]) * capacity);
+    }
+    struct dir_entry *dir_entry = &dir_contents[nitems++];
+    dir_entry->file_name = strdup(file_name);
+    dir_entry->is_dir = is_dir;
+}
+static const char *make_full_path(const char *dir_path, const char *file_name)
+{
+    size_t dir_len = strlen(dir_path);
+    char *ret = malloc(dir_len + 1 + strlen(file_name) + 1);
+    if (strcmp(file_name, "..") == 0) {
+        strcpy(ret, dir_path);
+        char *slash = strrchr(ret, '/');
+        if (!slash)
+            slash = strrchr(ret, '\\');
+        if (slash) {
+            if (slash[1] == '\0' && ret[1] == ':' && slash==ret+2) {
+                // If going up a directory from the root of a drive,
+                // go up to the list of drives rather than the current
+                // directory of the drive.
+                // i.e. "C:\" -> "" rather than "C:\" -> "C:"
+                ret[0] = '\0';
+            } else if (ret[1] == ':' && slash==ret+2) {
+                // If going up to the root of the drive don't erase
+                // the trailing slash.
+                slash[1] = '\0';
+            } else {
+                slash[0] = '\0';
+            }
+        }
+    } else {
+        strcpy(ret, dir_path);
+        if (dir_len > 0 &&
+            ret[dir_len - 1] != '/' &&
+            ret[dir_len - 1] != '\\')
+            strcat(ret, "/");
+        strcat(ret, file_name);
+    }
+    return ret;
+}
+static int compare_dir_entry(const void *p1, const void *p2)
+{
+    struct dir_entry *dir_entry1 = (struct dir_entry *)p1;
+    struct dir_entry *dir_entry2 = (struct dir_entry *)p2;
+    if (dir_entry1->is_dir != dir_entry2->is_dir)
+        return (dir_entry1->is_dir ? 0 : 1) - (dir_entry2->is_dir ? 0 : 1);
+    else
+        return strcmp(dir_entry1->file_name, dir_entry2->file_name);
+}
+static void list_dir(const char* path) {
+#ifdef NEXTP8
+    if (path[0] == '\0') {
+        free((char *)pwd);
+        pwd = strdup(path);
+        clear_dir_contents();
+        // Show drives
+        static const char *volume_names[2] = {"0:/", "1:/"};
+        for (int i=0;i<2;++i)
+            append_dir_entry(volume_names[i], true);
+        return;
+    }
+#endif
+    DIR *dir = opendir(path);
+    if (dir == NULL) {
+        fprintf(stderr, "1. %s: %s\n", path, strerror(errno));
+    } else {
+        free((char *)pwd);
+        pwd = strdup(path);
+        clear_dir_contents();
+        for (;;) {
+            struct dirent *dirent;
+            errno = 0;
+            dirent = readdir(dir);
+            if (dirent == NULL) {
+                if (errno != 0)
+                    fprintf(stderr, "2. %s: %s\n", path, strerror(errno));
+                break;
+            }
+            const char *full_path = make_full_path(path, dirent->d_name);
+            bool is_dir = false;
+            if (full_path[0] == '\0' ||
+                (full_path[1] == ':' &&
+                 (full_path[2] == '/' || full_path[2] == '\\') &&
+                 full_path[3] == '\0')) {
+                is_dir = true;
+            } else {
+                struct stat statbuf;
+                int res = stat(full_path, &statbuf);
+                if (res == 0)
+                    is_dir = S_ISDIR(statbuf.st_mode);
+                else
+                    fprintf(stderr, "3. %s: %s\n", full_path, strerror(errno));
+            }
+            free((char *)full_path);
+            append_dir_entry(dirent->d_name, is_dir);
+        }
+        closedir(dir);
+    }
+    qsort(dir_contents, nitems, sizeof(dir_contents[0]), compare_dir_entry);
+}
+
+#define LIST_TOP (GLYPH_HEIGHT + 1)
+#define LIST_HEIGHT (P8_HEIGHT - LIST_TOP)
+
+static void display_dir_contents()
+{
+    clear_screen(1);
+    draw_rectfill(0, 0, P8_WIDTH, GLYPH_HEIGHT, 7, 0);
+    draw_text(pwd, 0, 0, 1);
+    clip_set(0, LIST_TOP, P8_WIDTH, LIST_HEIGHT);
+    int y = LIST_TOP;
+    int scroll = current_item * GLYPH_HEIGHT + (GLYPH_HEIGHT - LIST_HEIGHT) / 2;
+    if (scroll > nitems * GLYPH_HEIGHT - LIST_HEIGHT) scroll = nitems * GLYPH_HEIGHT - LIST_HEIGHT;
+    if (scroll < 0) scroll = 0;
+    for (int i=0;i<nitems;++i) {
+        struct dir_entry *dir_entry = &dir_contents[i];
+        if (y - scroll > -GLYPH_HEIGHT && y - scroll < P8_HEIGHT) {
+            bool highlighted = (current_item == i);
+            if (highlighted)
+                draw_rectfill(0, y - scroll, P8_WIDTH - 1, y - scroll + GLYPH_HEIGHT - 1, 10, 0);
+            if (dir_entry->is_dir)
+                clip_set(0, LIST_TOP, P8_WIDTH - GLYPH_WIDTH * 6, LIST_HEIGHT);
+            int fg = highlighted ? 1 : 7;
+            draw_text(dir_entry->file_name, 0, y - scroll, fg);
+            if (dir_entry->is_dir)
+                clip_set(0, LIST_TOP, P8_WIDTH, LIST_HEIGHT);
+            if (dir_entry->is_dir) {
+                draw_text(" <DIR>", 128 - GLYPH_WIDTH * 6, y - scroll, fg);
+            }
+        }
+        y += GLYPH_HEIGHT;
+    }
+}
+
+const char *browse_for_cart(void)
+{
+    p8_init();
+    p8_reset();
+    if (setjmp(jmpbuf))
+        return NULL;
+    if (access(DEFAULT_PATH, F_OK) == 0)
+        list_dir(DEFAULT_PATH);
+    else
+        list_dir(FALLBACK_PATH);
+    uint8_t buttons = 0;
+    const char *cart_path = NULL;
+    for (;;) {
+        buttons = m_buttonsp[0];
+        if (buttons & BUTTON_UP) {
+            if (current_item > 0)
+                current_item--;
+        }
+        if (buttons & BUTTON_DOWN) {
+            if (current_item < nitems - 1)
+                current_item++;
+        }
+        if (buttons & BUTTON_ACTION1) {
+            struct dir_entry *dir_entry = &dir_contents[current_item];
+            const char *full_path = make_full_path(pwd, dir_entry->file_name);
+            if (dir_entry->is_dir) {
+                printf("list_dir >>%s<< pwd=>>%s<< file_name=>>%s<<\n", full_path, pwd, dir_entry->file_name);
+                list_dir(full_path);
+                free((char *)full_path);
+            } else {
+                cart_path = strdup(full_path);
+                break;
+            }
+        }
+        display_dir_contents();
+        p8_flip();
+    }
+    clear_dir_contents();
+    free(dir_contents);
+    free((char *)pwd);
+    // Wait for button release before loading.
+    // Otherwise the cart may respond to the button press.
+    do {
+        p8_update_input();
+    } while (m_buttons[0] & BUTTON_ACTION1);
+    return cart_path;
+}

--- a/src/p8_browse.h
+++ b/src/p8_browse.h
@@ -1,0 +1,10 @@
+/**
+ * Copyright (C) 2025 Chris January
+ */
+
+#ifndef P8_BROWSE_H
+#define P8_BROWSE_H
+
+const char *browse_for_cart(void);
+
+#endif

--- a/src/p8_emu.c
+++ b/src/p8_emu.c
@@ -7,7 +7,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <setjmp.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -56,6 +55,7 @@ static inline int color_index(uint8_t c)
 }
 
 static void p8_abort();
+static int p8_init_lcd(void);
 static void p8_main_loop();
 
 uint8_t *m_memory = NULL;
@@ -67,7 +67,7 @@ unsigned m_frames = 0;
 
 clock_t m_start_time;
 
-static jmp_buf jmpbuf;
+jmp_buf jmpbuf;
 static bool restart;
 
 #ifdef SDL
@@ -93,8 +93,12 @@ static bool m_prev_pointer_lock;
 static FILE *cartdata = NULL;
 static bool cartdata_needs_flush = false;
 
+static int m_initialized = 0;
+
 int p8_init()
 {
+    assert(!m_initialized);
+
     srand((unsigned int)time(NULL));
 
 #ifdef SDL
@@ -131,10 +135,14 @@ int p8_init()
     audio_init();
 #endif
 
+    p8_init_lcd();
+
+    m_initialized = 1;
+
     return 0;
 }
 
-int p8_init_lcd()
+static int p8_init_lcd(void)
 {
 #ifndef SDL
     gdi_set_layer_start(HW_LCDC_LAYER_0, 0, 0);
@@ -165,6 +173,8 @@ static void p8_init_common(const char *file_name, const char *lua_script)
 
     memcpy(m_memory, m_cart_memory, CART_MEMORY_SIZE);
 
+    clear_screen(0);
+
     p8_reset();
     p8_update_input();
 
@@ -179,9 +189,10 @@ static void p8_init_common(const char *file_name, const char *lua_script)
     p8_main_loop();
 }
 
-int p8_init_file(char *file_name)
+int p8_init_file(const char *file_name)
 {
-    p8_init();
+    if (!m_initialized)
+        p8_init();
 
     const char *lua_script = NULL;
     uint8_t *file_buffer = NULL;
@@ -201,7 +212,8 @@ int p8_init_file(char *file_name)
 
 int p8_init_ram(uint8_t *buffer, int size)
 {
-    p8_init();
+    if (!m_initialized)
+        p8_init();
 
     const char *lua_script = NULL;
     uint8_t *decompression_buffer = NULL;
@@ -240,6 +252,8 @@ int p8_shutdown()
     rh_free(m_cart_memory);
     rh_free(m_memory);
 #endif
+
+    m_initialized = 0;
 
     return 0;
 }

--- a/src/p8_emu.h
+++ b/src/p8_emu.h
@@ -9,7 +9,9 @@
 #define P8_EMU_H
 
 #include <limits.h>
+#include <setjmp.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __DA1470x__
@@ -175,18 +177,22 @@ extern uint8_t m_buttonsp[2];
 extern uint8_t m_button_first_repeat[2];
 extern unsigned m_button_down_time[2][6];
 
+extern jmp_buf jmpbuf;
+
 void p8_close_cartdata(void);
 void p8_delayed_flush_cartdata(void);
 unsigned p8_elapsed_time(void);
 void p8_flip(void);
 void p8_flush_cartdata(void);
-int p8_init_file(char *file_name);
+int p8_init(void);
+int p8_init_file(const char *file_name);
 int p8_init_ram(uint8_t *buffer, int size);
 bool p8_open_cartdata(const char *id);
 int p8_shutdown(void);
 void p8_render();
 void p8_reset(void);
 void __attribute__ ((noreturn)) p8_restart(void);
+int p8_shutdown(void);
 void p8_update_input(void);
 
 #endif


### PR DESCRIPTION
Show a file browser for carts if no cart was supplied on the command line.

This was originally for the nextp8 port to have some way of selecting a cart.

Ideally the cart graphic would be shown for .p8.png carts, but I don't have any threading library on the Next and blocking to load the image would make it too slow to select a cart.