### PR TITLE
on OpenBSD, include stdlib.h for malloc

### DIFF
--- a/src/p8_browse.c
+++ b/src/p8_browse.c
@@ -8,6 +8,8 @@
 #if defined(__APPLE__)
   #include <stdlib.h>
   #include <malloc/malloc.h>
+#elif defined(__OpenBSD__)
+  #include <stdlib.h>
 #else
   #include <malloc.h>
 #endif


### PR DESCRIPTION
Small addition for building on OpenBSD. Great project, I'm already running cartridges on OpenBSD with this small fix!